### PR TITLE
Allow usage of #tryinclude

### DIFF
--- a/include/discordWebhookAPI.inc
+++ b/include/discordWebhookAPI.inc
@@ -1,4 +1,9 @@
-﻿#include <ripext>
+#if defined _discordWebhookAPI_included_
+  #endinput
+#endif
+#define _discordWebhookAPI_included_
+
+#include <ripext>
 
 methodmap EmbedFooter < JSONObject
 {


### PR DESCRIPTION
This small change allow user to use `#tryinclude <discordWebhookAPI>`